### PR TITLE
+ Add SpecifiedTradeAllowanceCharge to IncludedSupplyChainTradeLineIt…

### DIFF
--- a/src/XmlConverterUblToCii.php
+++ b/src/XmlConverterUblToCii.php
@@ -390,6 +390,30 @@ class XmlConverterUblToCii extends XmlConverterBase
                     }
                 );
 
+                $this->source->queryAll('./cac:AllowanceCharge', $invoiceLineNode)->forEach(
+                    function ($allowanceChargeNode) {
+                        $this->destination->startElement('ram:SpecifiedTradeAllowanceCharge');
+
+                        $this->source->whenExists(
+                            './cbc:ChargeIndicator',
+                            $allowanceChargeNode,
+                            function ($chargeIndicatorNode) {
+                                $this->destination->startElement('ram:ChargeIndicator');
+                                $this->destination->element('udt:Indicator', $chargeIndicatorNode->nodeValue);
+                                $this->destination->endElement();
+                            }
+                        );
+
+                        $this->destination->element('ram:CalculationPercent', $this->source->queryValue('./cbc:MultiplierFactorNumeric', $allowanceChargeNode));
+                        $this->destination->element('ram:BasisAmount', $this->source->queryValue('./cbc:BaseAmount', $allowanceChargeNode));
+                        $this->destination->element('ram:ActualAmount', $this->source->queryValue('./cbc:Amount', $allowanceChargeNode));
+                        $this->destination->element('ram:ReasonCode', $this->source->queryValue('./cbc:AllowanceChargeReasonCode', $allowanceChargeNode));
+                        $this->destination->element('ram:Reason', $this->source->queryValue('./cbc:AllowanceChargeReason', $allowanceChargeNode));
+
+                        $this->destination->endElement();
+                    }
+                );
+
                 $this->destination->endElement();
 
                 $this->destination->endElement();


### PR DESCRIPTION
The AllowanceCharge under the InvoiceLine is not converted.
This means that no position discounts can be converted.

Example:
```
  <cac:InvoiceLine>
    <cac:AllowanceCharge>
      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
      <cbc:AllowanceChargeReason>A</cbc:AllowanceChargeReason>
      <cbc:MultiplierFactorNumeric>36</cbc:MultiplierFactorNumeric>
      <cbc:Amount currencyID="EUR">15.39</cbc:Amount>
      <cbc:BaseAmount currencyID="EUR">42.75</cbc:BaseAmount>
    </cac:AllowanceCharge>
  </cac:InvoiceLine>
```

Fixes # (issue)

The fix convertes it to:

```
   <ram:IncludedSupplyChainTradeLineItem>
      <ram:SpecifiedLineTradeSettlement>
        <ram:SpecifiedTradeAllowanceCharge>
          <ram:ChargeIndicator>
            <udt:Indicator>false</udt:Indicator>
          </ram:ChargeIndicator>
          <ram:CalculationPercent>36</ram:CalculationPercent>
          <ram:BasisAmount>33.45</ram:BasisAmount>
          <ram:ActualAmount>12.04</ram:ActualAmount>
          <ram:Reason>A</ram:Reason>
        </ram:SpecifiedTradeAllowanceCharge>
      </ram:SpecifiedLineTradeSettlement>
    </ram:IncludedSupplyChainTradeLineItem>
```


